### PR TITLE
Add oem-iptables-init.sh for Wi-Fi calling in airplane mode

### DIFF
--- a/lynx/proprietary-files.txt
+++ b/lynx/proprietary-files.txt
@@ -80,6 +80,11 @@ product/priv-app/AppDirectedSMSService/AppDirectedSMSService.apk;PRESIGNED
 product/priv-app/OemDmTrigger/OemDmTrigger.apk
 product/priv-app/WfcActivation/WfcActivation.apk;PRESIGNED
 
+# system partition
+
+# IMS
+system/bin/oem-iptables-init.sh
+
 # system_ext partition
 
 # Camera extensions


### PR DESCRIPTION
This was added recently in Android 15, see the following commit: https://android.googlesource.com/device/google/gs101/+/fbf009b886cb6391b0833ab147a18c4cf9adda0d

Issue: calyxos#2813
Change-Id: I853f087347795e1d8932db2020f8a69fb5d97fa6